### PR TITLE
feat(template): added template for cssObject

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,17 +46,21 @@ function renderCSSToReactNative(css) {
   return css2rn(css, { parseMediaQueries: true });
 }
 
-module.exports.transform = function(src, filename, options) {
+function defaultTemplate(cssObject) {
+  return "module.exports = " + JSON.stringify(cssObject);
+}
+
+module.exports.transform = function(src, filename, options, template) {
   if (typeof src === "object") {
     // handle RN >= 0.46
-    ({ src, filename, options } = src);
+    ({ src, filename, options, template } = src);
   }
 
   if (filename.endsWith(".less")) {
     return renderToCSS({ src, filename, options }).then(css => {
       var cssObject = renderCSSToReactNative(css);
       return upstreamTransformer.transform({
-        src: "module.exports = " + JSON.stringify(cssObject),
+        src: template ? template(cssObject) : defaultTemplate(cssObject),
         filename,
         options
       });


### PR DESCRIPTION
Adds the ability to create your own file template.
Useful when you need to export wrapped in StyleSheet.create

```js
return lessTransformer.transform({
        src,
        filename,
        options: {...options, lessOptions},
        template: cssObject =>
          `var RN = require('react-native'); module.exports = RN.StyleSheet.create(${JSON.stringify(
            cssObject,
          )});`,
      });
```