### PR TITLE
Some fix in metro.config.js example

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ module.exports = (() => {
   };
   config.resolver = {
     ...resolver,
-    sourceExts: [...sourceExts, "less"]
+    sourceExts: [...resolver.sourceExts, "less"]
   };
 
   return config;


### PR DESCRIPTION
Some little fix in README. In this example sourceExts is undefined